### PR TITLE
Corrected typo in /health endpoint route

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,7 +6,7 @@ from app.models import Item, ItemCreate, ItemUpdate
 app = FastAPI()
 
 
-@app.get("/heath")
+@app.get("/health")
 def health_check() -> dict[str, str]:
     return {"status": "ok"}
 


### PR DESCRIPTION
This PR fixes a typo in the "/health" endpoint route. The route was previously "/heath", which caused 1 test failure.