### PR TITLE
Corrected min_price filter logic

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -5,7 +5,7 @@ from app.models import Item, ItemCreate, ItemUpdate
 
 
 def get_items(min_price: float = 0.0) -> List[Item]:
-    return [Item(**item) for item in items_db if item["price"] <= min_price]
+    return [Item(**item) for item in items_db if item["price"] >= min_price]
 
 
 def create_item(item: ItemCreate) -> Item:


### PR DESCRIPTION
This PR fixes the filtering logic in the get_items function inside crud.py. Previously, the function returned items with a price less than or equal to min_price, which was incorrect. Now, it properly returns items with a price greater than or equal to min_price, as intended.

The test related to the min_price filter function now passes correctly.