### PR TITLE
Added name length validation for item creation and updates, with corresponding test

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -10,7 +10,7 @@ class Item(BaseModel):
 
 
 class ItemCreate(BaseModel):
-    name: str = Field(...)
+    name: str = Field(..., min_length=3)
     price: float
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -15,5 +15,5 @@ class ItemCreate(BaseModel):
 
 
 class ItemUpdate(BaseModel):
-    name: Optional[str] = None
+    name: Optional[str] = Field(default=None, min_length=3)
     price: Optional[float] = None

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -31,3 +31,9 @@ def test_item_name_consistency() -> None:
     response = client.get("/items")
     names = [item["name"] for item in response.json()]
     assert "Item500000" in names
+
+def test_update_with_short_name() -> None:
+    create_resp = client.post("/items", json={"name": "Apple", "price": 3.5})
+    item_id = create_resp.json()["id"]
+    update_resp = client.put(f"/items/{item_id}", json={"name": "ab"})
+    assert update_resp.status_code == 422


### PR DESCRIPTION
This PR includes:

Validation Enforcement - Added min_length=3 to the name field in both ItemCreate and ItemUpdate models to ensure item names have at least 3 characters, as intended by the business logic.

Test Coverage - Created a test case to confirm that updating an item with a name shorter than 3 characters returns a 422 code error, verifying that the validation is effective.