### PR TITLE
Added pagination to /items endpoint

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -4,8 +4,10 @@ from app.database import items_db
 from app.models import Item, ItemCreate, ItemUpdate
 
 
-def get_items(min_price: float = 0.0) -> List[Item]:
-    return [Item(**item) for item in items_db if item["price"] >= min_price]
+def get_items(min_price: float = 0.0, skip: int = 0, limit: int = 100) -> List[Item]:
+    filtered = (item for item in items_db if item["price"] >= min_price)
+    sliced = list(filtered)[skip:skip + limit]
+    return [Item(**item) for item in sliced]
 
 
 def create_item(item: ItemCreate) -> Item:

--- a/app/main.py
+++ b/app/main.py
@@ -12,8 +12,13 @@ def health_check() -> dict[str, str]:
 
 
 @app.get("/items")
-def list_items(min_price: float = Query(0.0)) -> list[Item]:
-    return get_items(min_price=min_price)
+def list_items(
+    min_price: float = Query(0.0),
+    skip: int = Query(0, ge=0),
+    limit: int = Query(100, gt=0, le=100)
+) -> list[Item]:
+    return get_items(min_price=min_price, skip=skip, limit=limit)
+
 
 
 @app.post("/items")

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -37,3 +37,9 @@ def test_update_with_short_name() -> None:
     item_id = create_resp.json()["id"]
     update_resp = client.put(f"/items/{item_id}", json={"name": "ab"})
     assert update_resp.status_code == 422
+    
+def test_pagination() -> None:
+    for i in range(150):
+        client.post("/items", json={"name": f"Item{i}", "price": i})
+    resp = client.get("/items?min_price=0&skip=100&limit=50")
+    assert len(resp.json()) == 50

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -39,7 +39,6 @@ def test_update_with_short_name() -> None:
     assert update_resp.status_code == 422
     
 def test_pagination() -> None:
-    for i in range(150):
-        client.post("/items", json={"name": f"Item{i}", "price": i})
-    resp = client.get("/items?min_price=0&skip=100&limit=50")
+    resp = client.get("/items?min_price=4&skip=50&limit=50")
     assert len(resp.json()) == 50
+    assert all(item["price"] >= 4 for item in resp.json())


### PR DESCRIPTION
This PR added pagination functionality to the /items endpoint using skip and limit parameters. Pagination now allows controlling the number of items returned per request, making it easier to handle performance issues as the item list grows.