### PR TITLE
Improved update_item handler & endpoint

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -17,12 +17,22 @@ def create_item(item: ItemCreate) -> Item:
     return Item(**new_item)
 
 
+def get_item_by_id(item_id: int) -> dict | None:
+    return next((item for item in items_db if item["id"] == item_id), None)
+
+
 def update_item_by_id(item_id: int, update: ItemUpdate) -> Item | None:
     for item in items_db:
         if item["id"] == item_id:
+            if update.name and any(
+                existing_item["name"] == update.name and existing_item["id"] != item_id
+                for existing_item in items_db
+            ):
+                return None
+
             if update.name:
                 item["name"] = update.name
             if update.price:
                 item["price"] = update.price
+
             return Item(**item)
-    return None

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, HTTPException, Query
 
-from app.crud import create_item, get_items, update_item_by_id
+from app.crud import create_item, get_items, update_item_by_id, get_item_by_id
 from app.models import Item, ItemCreate, ItemUpdate
 
 app = FastAPI()
@@ -28,7 +28,13 @@ def add_item(item: ItemCreate) -> Item:
 
 @app.put("/items/{item_id}")
 def update_item(item_id: int, item: ItemUpdate) -> Item:
+    existing = get_item_by_id(item_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Item not found")
+    
     updated = update_item_by_id(item_id, item)
     if not updated:
-        raise HTTPException(status_code=404, detail="Item not found or duplicate name")
+        raise HTTPException(status_code=422, detail="Duplicate item name")
+
     return updated
+

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -32,11 +32,13 @@ def test_item_name_consistency() -> None:
     names = [item["name"] for item in response.json()]
     assert "Item500000" in names
 
+
 def test_update_with_short_name() -> None:
     create_resp = client.post("/items", json={"name": "Apple", "price": 3.5})
     item_id = create_resp.json()["id"]
     update_resp = client.put(f"/items/{item_id}", json={"name": "ab"})
     assert update_resp.status_code == 422
+    
     
 def test_pagination() -> None:
     resp = client.get("/items?min_price=4&skip=50&limit=50")


### PR DESCRIPTION
In this PR the logic in update_item_by_id and the corresponding API endpoint were updated to ensure that item names remain unique. If an update request attempts to change an item's name to one that already exists, the operation is now properly blocked, and no changes are made. This prevents data inconsistencies.